### PR TITLE
change from git:// to http:// URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "node_modules/buster"]
 	path = node_modules/buster
-	url = git://gitorious.org/buster/buster.git
+	url = https://git.gitorious.org/buster/buster.git
 [submodule "node_modules/sinon"]
 	path = node_modules/sinon
-	url = git@github.com:cjohansen/Sinon.JS.git
+	url = https://github.com:cjohansen/Sinon.JS.git
 [submodule "node_modules/buster-script-loader"]
 	path = node_modules/buster-script-loader
-	url = git://gitorious.org/buster/buster-script-loader.git
+	url = https://git.gitorious.org/buster/buster-script-loader.git


### PR DESCRIPTION
Many work firewalls block git:// URLs. This small change points buster's dependencies and submodules to use the HTTP URLs. NPM made [the same change](https://github.com/isaacs/npm/issues/1187) a while back. 
